### PR TITLE
Corrected to_hash to be usable with ruby1.8

### DIFF
--- a/lib/raven/interfaces.rb
+++ b/lib/raven/interfaces.rb
@@ -17,7 +17,11 @@ module Raven
     end
 
     def to_hash
-      Hash[instance_variables.map { |name| [name[1..-1].to_sym, instance_variable_get(name)] } ]
+      data = {}
+      instance_variables.each do |var|
+        data[var[1..-1].to_sym] = instance_variable_get(var)
+      end
+      data
     end
   end
 


### PR DESCRIPTION
## Description
There is a bug in raven-ruby with ruby1.8 as error are send to sentry but payload sent by raven-ruby is incorrect and prevent seeing stacktrace in sentry GUI or grouping correctly related events.
This is due to a bug in ruby1.8 happening in to_hash function.

This PR correct function so that payload will be correct and error will be correctly displayed in sentry interface.

## How to test
  - https://github.com/dakis/cashier/pull/362
