### PR TITLE
[ENHANCEMENT] Don't raise sentry event on ActionController::MethodNotAllowed errors

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -107,6 +107,7 @@ module Raven
       'ActionController::InvalidAuthenticityToken',
       'ActionController::RoutingError',
       'ActionController::UnknownAction',
+      'ActionController::MethodNotAllowed',
       'ActiveRecord::RecordNotFound',
       'CGI::Session::CookieStore::TamperedWithCookie',
       'Mongoid::Errors::DocumentNotFound',


### PR DESCRIPTION
## Description
We do not want `ActionController::MethodNotAllowed` exceptions to be logged in sentry.
This change is about disabling these exceptions from sentry by default.

## Test
https://github.com/dakis/webpim/pull/255