### PR TITLE
[FIX][MAIN-260] Send environment variable to sentry

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -26,7 +26,7 @@ module Raven
     attr_reader :id
     attr_accessor :project, :message, :timestamp, :time_spent, :level, :logger,
       :culprit, :server_name, :release, :modules, :extra, :tags, :context, :configuration,
-      :checksum, :fingerprint
+      :checksum, :fingerprint, :environment
 
     def initialize(init = {})
       @configuration = Raven.configuration
@@ -48,6 +48,8 @@ module Raven
       @tags          = {}
       @checksum      = nil
       @fingerprint   = nil
+
+      @environment = @configuration.current_environment
 
       yield self if block_given?
 
@@ -115,6 +117,8 @@ module Raven
       data[:tags] = @tags if @tags
       data[:user] = @user if @user
       data[:checksum] = @checksum if @checksum
+      data[:environment] = @environment if @environment
+
       @interfaces.each_pair do |name, int_data|
         data[name.to_sym] = int_data.to_hash
       end


### PR DESCRIPTION
## Description
  - Why are you making these changes? Inventory/legacy is reporting to sentry, but its not sending the environment
  - What are your changes? Added the environment to the event hash, as per the master branch. Likely the sentry API has deprecated parsing the environment within the `configuration` key.

## How to test
  - This test branch was deployed to docker https://github.com/dakis/inventory/compare/fix/send_env_to_sentry...test/send_env_to_sentry?expand=1 over at http://csf.vu7grsh0.docker.mydakis.com/#/en/login
  - Go to the `Photo` page for any retailer. It should crash and report a funky error with the docker environment to sentry